### PR TITLE
Improve challenge rating display

### DIFF
--- a/src/components/sections/Prompts.js
+++ b/src/components/sections/Prompts.js
@@ -53,7 +53,7 @@ const Prompts = () => {
                                         <h3 className="prompt-title">{prompt.title}</h3>
                                     </div>
                                     <span className="difficulty-badge">
-                                        {prompt.difficulty}
+                                        Challenge Rating: {prompt.difficulty}
                                     </span>
                                 </div>
 

--- a/src/data/prompts.js
+++ b/src/data/prompts.js
@@ -22,6 +22,6 @@ export const promptsData = [
     id: 4,
     title: 'Game Development Challenge',
     description: 'Create a small game prototype around a surprise summer theme.',
-    difficulty: '1-5/5'
+    difficulty: '2/5'
   },
 ];


### PR DESCRIPTION
## Summary
- show 'Challenge Rating: x/5' on category pills
- correct game development category difficulty to `2/5`

## Testing
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688a8e6bbb588332aaa551914717c913